### PR TITLE
rex.graphql: report Type.Field when validating args

### DIFF
--- a/src/rex.graphql/doc/guide-db-queries.rst
+++ b/src/rex.graphql/doc/guide-db-queries.rst
@@ -187,7 +187,7 @@ It's an error not to pass ``name`` argument now::
    ...   }
    ... """)
    >>> result.errors
-   [GraphQLError('Argument "name" of required type String!" was not provided.',)]
+   [GraphQLError('Argument "name" of required type String!" was not provided. At Root.region.',)]
 
 But if we pass ``name`` then everything is ok::
 

--- a/src/rex.graphql/src/rex/graphql/model.py
+++ b/src/rex.graphql/src/rex/graphql/model.py
@@ -308,6 +308,12 @@ class Field(SchemaNode):
 
     params = NotImplemented
 
+    def __init__(self, name, descriptor, type, params):
+        self.name = name
+        self.descriptor = descriptor
+        self.type = type
+        self.params = params
+
     @cached_property.cached_property
     def args(self):
         return {
@@ -319,11 +325,6 @@ class Field(SchemaNode):
 
 class ComputedField(Field):
     """ Fields computed with resolver."""
-
-    def __init__(self, descriptor, type, params):
-        self.descriptor = descriptor
-        self.type = type
-        self.params = params
 
     resolver = property(lambda self: self.descriptor.resolver)
     description = property(lambda self: self.descriptor.description)
@@ -341,12 +342,10 @@ class ComputedField(Field):
 
 
 class QueryField(Field):
-    def __init__(self, descriptor, type, plural, optional, params):
-        self.descriptor = descriptor
+    def __init__(self, name, descriptor, type, params, plural, optional):
+        super(QueryField, self).__init__(name, descriptor, type, params)
         self.plural = plural
         self.optional = optional
-        self.type = type
-        self.params = params
 
     loc = property(lambda self: self.descriptor.loc)
     description = property(lambda self: self.descriptor.description)
@@ -743,7 +742,7 @@ def _(descriptor, ctx, name):
         for param_name, param in descriptor.params.items():
             params[param_name] = construct(param, ctx)
 
-        return ComputedField(descriptor=descriptor, type=type, params=params)
+        return ComputedField(name=name, descriptor=descriptor, type=type, params=params)
 
 
 def synthesize_id(d):
@@ -929,11 +928,12 @@ def _(descriptor, ctx, name):
             ctx.root.types[named_type.name] = named_type
 
         return QueryField(
+            name=name,
             descriptor=descriptor,
-            optional=output.optional,
-            plural=output.plural,
             type=type,
             params=params,
+            optional=output.optional,
+            plural=output.plural,
         )
 
 

--- a/src/rex.graphql/test/test_graphql.py
+++ b/src/rex.graphql/test/test_graphql.py
@@ -1017,7 +1017,7 @@ def test_enum():
             )
         }
     )
-    assert execute(sch, '{sameday(day: sun)}') == {"sameday": "sun"}
+    assert execute(sch, "{sameday(day: sun)}") == {"sameday": "sun"}
     # XXX(andreypopp): this is for backward compat: we allow string literals as
     # well.
     assert execute(sch, '{sameday(day: "sun")}') == {"sameday": "sun"}
@@ -1187,7 +1187,7 @@ def test_err_query_arg_type_mismatch():
         )
     assert (
         info.value.message
-        == 'Argument "count : Int!" (supplied by "$count" variable) was not provided'
+        == 'Argument "count : Int!" (supplied by "$count" variable) was not provided. At Root.region.'
     )
 
     with pytest.raises(GraphQLError) as info:
@@ -1198,7 +1198,8 @@ def test_err_query_arg_type_mismatch():
         )
     assert (
         info.value.message
-        == 'Variable "$count : String" is attempted to be used as a value of incompatible type "Int!"'
+        == ('Variable "$count : String" is attempted to be used as a value of incompatible type "Int!".'
+            ' At Root.region.')
     )
 
 


### PR DESCRIPTION
See updated tests for details, the error now contains Type.Field in its message
so it's easier to identify the offending location.