### PR TITLE
JS: pin lodash version to ^4.17.12

### DIFF
--- a/js/react-dom-stylesheet/package.json
+++ b/js/react-dom-stylesheet/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "inline-style-prefix-all": "^2.0.2",
     "prop-types": "^15.0.0",
-    "lodash": "^4.13.1",
+    "lodash": "^4.17.12",
     "murmurhash-js": "^1.0.0",
     "react-css-property-operations": "^15.4.1",
     "react": "*",

--- a/js/react-forms/package.json
+++ b/js/react-forms/package.json
@@ -43,7 +43,7 @@
     "generate-object-property": "^1.1.0",
     "invariant": "^2.2.1",
     "jsonpointer": "^3.0.0",
-    "lodash": "^4.0.0",
+    "lodash": "^4.17.12",
     "memoize-decorator": "^1.0.2",
     "react-derivable": "^0.2.0",
     "react-stylesheet-old": "*"

--- a/js/react-ui-0.21/package.json
+++ b/js/react-ui-0.21/package.json
@@ -35,7 +35,7 @@
     "@prometheusresearch/react-box": "^0.10.0",
     "color-js": "^1.0.3",
     "invariant": "^2.2.1",
-    "lodash": "^4.13.0",
+    "lodash": "^4.17.12",
     "react-dom-stylesheet": "*",
     "react-stylesheet-old": "*"
   }

--- a/js/rex-action/lib/ObjectTemplate.js
+++ b/js/rex-action/lib/ObjectTemplate.js
@@ -4,17 +4,19 @@
 
 import * as KeyPath from 'rex-widget/KeyPath';
 import invariant from 'invariant';
-import isPlainObject from 'lodash/lang/isPlainObject';
-import isArray from 'lodash/lang/isArray';
 import {isEntity} from './model/Entity';
+
+function isObject(v: mixed) {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
 
 /**
  * Render object `template` with the provided `context`.
  */
 export function render(template: mixed, context: Object): mixed {
-  if (isArray(template)) {
+  if (Array.isArray(template)) {
     return renderArray(template, context);
-  } else if (isPlainObject(template)) {
+  } else if (isObject(template)) {
     return renderObject(template, context);
   } else {
     invariant(
@@ -40,7 +42,7 @@ function renderObject(template, context) {
       rendered[key] = value;
     } else {
       rendered[key] = item;
-      if (isPlainObject(rendered[key])) {
+      if (isObject(rendered[key])) {
         rendered[key] = render(rendered[key], context);
       }
     }

--- a/js/rex-action/package.json
+++ b/js/rex-action/package.json
@@ -24,7 +24,6 @@
     "empty": "^0.10.1",
     "escape-regexp": "0.0.1",
     "invariant": "^2.1.1",
-    "lodash": "^3.10.1",
     "qs": "^6.4.0",
     "react-stylesheet": "*",
     "prop-types": "^15.0.0"

--- a/js/rex-forms/package.json
+++ b/js/rex-forms/package.json
@@ -29,7 +29,7 @@
     "derivable": "1.0.0-beta11",
     "invariant": "^2.2.1",
     "jscreole": "prometheusresearch/jscreole#inline-markup",
-    "lodash": "^4.12.0",
+    "lodash": "^4.17.12",
     "react-icons": "^2.1.0",
     "react-input-mask": "^2.0.0"
   }

--- a/js/rex-mart-actions/package.json
+++ b/js/rex-mart-actions/package.json
@@ -13,7 +13,7 @@
     "react-stylesheet": "*",
     "react-window": "^1.8.3",
     "react-virtualized-auto-sizer": "*",
-    "lodash": "^4.15.0",
+    "lodash": "^4.17.12",
     "downloadjs": "^1.4.6",
     "moment": "^2.15.2",
     "debounce-promise": "^2.1.1",

--- a/js/rex-query/package.json
+++ b/js/rex-query/package.json
@@ -17,7 +17,7 @@
     "debug": "^2.6.0",
     "downloadjs": "^1.4.6",
     "invariant": "^2.2.1",
-    "lodash": "^4.15.0",
+    "lodash": "^4.17.12",
     "moment": "^2.15.2",
     "prop-types": "^15.5.8",
     "qs": "^6.2.1",

--- a/js/rex-widget/form/Form.js
+++ b/js/rex-widget/form/Form.js
@@ -5,7 +5,7 @@
 
 import * as React from "react";
 import { createValue, type schema, type value, type error } from "react-forms";
-import debounce from "lodash/function/debounce";
+import debounce from "lodash/debounce";
 import * as rexui from "rex-ui";
 import {
   ConfirmNavigation,

--- a/js/rex-widget/form/Validation.js
+++ b/js/rex-widget/form/Validation.js
@@ -4,7 +4,6 @@
 
 import moment from 'moment';
 import {toSnakeCase} from '../lang';
-import {isPlainObject} from 'lodash/lang';
 
 export const DATETIME_ISO_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 export const DATETIME_ISO_FORMAT_MILLIS = 'YYYY-MM-DD HH:mm:ss.SSSS';
@@ -19,8 +18,12 @@ export function string(value, node) {
   return true;
 }
 
+function isObject(v) {
+  return typeof v === 'object' && !Array.isArray(v) && v !== null;
+}
+
 export function json(value, node) {
-  if (!isPlainObject(value)) {
+  if (!isObject(value)) {
     try {
       JSON.parse(value);
     } catch (exc) {

--- a/js/rex-widget/package.json
+++ b/js/rex-widget/package.json
@@ -32,7 +32,7 @@
     "generate-function": "^2.0.0",
     "immupdate": "^0.1.3",
     "invariant": "^2.1.0",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.12",
     "normalize.css": "^3.0.3",
     "qs": "^4.0.0",
     "react-codemirror": "^1.0.0",

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -9668,7 +9668,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@*, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.12.0, lodash@^4.13.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.4, lodash@~4.17.5:
+lodash@*, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.4, lodash@~4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -9677,6 +9677,11 @@ lodash@^3.10.1, lodash@^3.3.1, lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
+
+lodash@^4.17.12:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 lodash@~0.9.2:
   version "0.9.2"


### PR DESCRIPTION
Also get rid of lodash in a few places where lodash 3.x was required.

This should fix the security warning GitHub produces, although I'm not aware we use any of those functions mentioned in the report.