### PR TITLE
Makefile: ignore node_modules when doing sync-once

### DIFF
--- a/.stignore
+++ b/.stignore
@@ -12,7 +12,7 @@ dist
 build
 node_modules
 bundle
-tweak/shell
+tweak/shell/vendor
 static/www/doc
 static/www/docs
 static/www/ravenjs

--- a/Makefile
+++ b/Makefile
@@ -415,6 +415,8 @@ sync-once:
 		--exclude /.st/ \
 		--exclude /.devmode \
 		--exclude /.kubeconfig \
+		--exclude /js/node_modules \
+		--exclude '/js/*/node_modules' \
 		--exclude '.*.sw?' \
 		--exclude /bin/ \
 		./ develop:/app/

--- a/Makefile
+++ b/Makefile
@@ -411,14 +411,8 @@ start: ./bin/activate #: start application daemons using development configurati
 
 sync-once:
 	${RSYNC} \
-		--exclude /.git/ \
-		--exclude /.st/ \
-		--exclude /.devmode \
-		--exclude /.kubeconfig \
-		--exclude /js/node_modules \
-		--exclude '/js/*/node_modules' \
-		--exclude '.*.sw?' \
-		--exclude /bin/ \
+		--include='/src/*/demo/static/www/bundle' \
+		--exclude-from=.stignore \
 		./ develop:/app/
 
 


### PR DESCRIPTION
In some cases node_modules might be already populated (when doing just FE
development).

@xitology it seems like `syncthing` already ignores everything which is inside `.gitignore`, am I right?