### PR TITLE
Remove Usage of Deprecated getargspec()

### DIFF
--- a/src/rex.core/src/rex/core/cache.py
+++ b/src/rex.core/src/rex/core/cache.py
@@ -113,6 +113,7 @@ def _decorate(fn, Gate=None, prefix='cached_', spec=None):
     if spec is None:
         spec = inspect.getfullargspec(fn)
     assert (spec.varkw is None and
+            not spec.kwonlyargs and
             not any(arg.startswith('_') for arg in spec.args)), \
                     "cached function may only have positional arguments: %s" \
                     % repr(spec)
@@ -134,7 +135,7 @@ def _decorate(fn, Gate=None, prefix='cached_', spec=None):
         signature.append('*'+spec.varargs)
         key.append(spec.varargs)
     if Gate is None:
-        lineno = _decorate.__code__.co_firstlineno + 28 # from `def` to `source`
+        lineno = _decorate.__code__.co_firstlineno + 29 # from `def` to `source`
         source = """\
             def {name}({signature}):
                 _cache = _get_rex().cache
@@ -145,7 +146,7 @@ def _decorate(fn, Gate=None, prefix='cached_', spec=None):
                     return _cache.set_default_cb(_key, _fn, {params})
         """
     else:
-        lineno = _decorate.__code__.co_firstlineno + 39 # from `def` to `source`
+        lineno = _decorate.__code__.co_firstlineno + 40 # from `def` to `source`
         source = """\
             def {name}({signature}):
                 _cache = _get_rex().cache
@@ -205,13 +206,14 @@ def autoreload(fn):
     spec = inspect.getfullargspec(fn)
     assert (spec.args[-1:] == ['open'] and
             spec.defaults == (open,) and
-            spec.varkw is None and
             spec.varargs is None and
+            spec.varkw is None and
+            not spec.kwonlyargs and
             not any(arg.startswith('_') for arg in spec.args)), \
                     "auto-reloading function may only have positional arguments" \
                     " with last argument being open=open: %s" % repr(spec)
     # Remove `open=open` from the list of arguments.
-    spec = spec.__class__(spec.args[:-1], None, None, None, None, None, None)
+    spec = spec.__class__(spec.args[:-1], None, None, None, [], None, spec.annotations)
     return _decorate(fn, OpenGate, prefix='autoreload_', spec=spec)
 
 

--- a/src/rex.core/src/rex/core/cache.py
+++ b/src/rex.core/src/rex/core/cache.py
@@ -111,8 +111,8 @@ def _decorate(fn, Gate=None, prefix='cached_', spec=None):
     # Returns a decorated function which value is stored in the application
     # cache.  If `Gate` is provided, use it as the value container.
     if spec is None:
-        spec = inspect.getargspec(fn)
-    assert (spec.keywords is None and
+        spec = inspect.getfullargspec(fn)
+    assert (spec.varkw is None and
             not any(arg.startswith('_') for arg in spec.args)), \
                     "cached function may only have positional arguments: %s" \
                     % repr(spec)
@@ -202,16 +202,16 @@ def autoreload(fn):
     The function must have only positional arguments with the last argument
     being ``open=open``.
     """
-    spec = inspect.getargspec(fn)
+    spec = inspect.getfullargspec(fn)
     assert (spec.args[-1:] == ['open'] and
             spec.defaults == (open,) and
-            spec.keywords is None and
+            spec.varkw is None and
             spec.varargs is None and
             not any(arg.startswith('_') for arg in spec.args)), \
                     "auto-reloading function may only have positional arguments" \
                     " with last argument being open=open: %s" % repr(spec)
     # Remove `open=open` from the list of arguments.
-    spec = spec.__class__(spec.args[:-1], None, None, None)
+    spec = spec.__class__(spec.args[:-1], None, None, None, None, None, None)
     return _decorate(fn, OpenGate, prefix='autoreload_', spec=spec)
 
 

--- a/src/rex.deploy/src/rex/deploy/fact.py
+++ b/src/rex.deploy/src/rex/deploy/fact.py
@@ -559,7 +559,7 @@ class Fact(Extension):
         """
         if not kwds:
             return self
-        spec = inspect.getargspec(self.__init__)
+        spec = inspect.getfullargspec(self.__init__)
         for arg in spec.args[1:]:
             kwds.setdefault(arg, getattr(self, arg))
         return self.__class__(**kwds)

--- a/src/rex.widget/src/rex/widget/field.py
+++ b/src/rex.widget/src/rex/widget/field.py
@@ -126,7 +126,7 @@ class ComputedField(FieldBase):
         super(ComputedField, self).__init__(
             name=name or computator.__name__,
             doc=doc or computator.__doc__)
-        argspec = inspect.getargspec(computator)
+        argspec = inspect.getfullargspec(computator)
         self._needs_request = len(argspec.args) > 1
         self.computator = computator
 


### PR DESCRIPTION
When deprecation warnings are enabled, we get spammed with: `DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()`

This should resolve these.