### PR TITLE
Fixed Crash When Using Mixed Option Styles in Plurals

### DIFF
--- a/src/rex.ctl/src/rex/ctl/core.py
+++ b/src/rex.ctl/src/rex/ctl/core.py
@@ -765,8 +765,8 @@ def _parse_argv(argv):
                     attrs[opt.attr] = value
                 else:
                     if opt.attr not in attrs:
-                        attrs[opt.attr] = []
-                    attrs[opt.attr].append(value)
+                        attrs[opt.attr] = ()
+                    attrs[opt.attr] += (value,)
 
         # Option or a collection of options in short form.
         elif param.startswith('-') and param != '-' and not no_more_opts:


### PR DESCRIPTION
When you have an option defined with a long-style name, and try to mix usage of them when invoking the Task, it can crash depending on what order you specify them. For example:

```
$ rex some-command -o one -o two
('one', 'two')
$ rex some-command --option=one --option=two
('one', 'two')
$ rex some-command --option=one -o two
('one', 'two')
$ rex some-command -o one --option=two
Traceback (most recent call last):
  File "/app/src/rex.ctl/src/rex/ctl/core.py", line 623, in main
    run(sys.argv)
  File "/app/src/rex.ctl/src/rex/ctl/core.py", line 975, in run
    task, attrs = _parse_argv(argv)
  File "/app/src/rex.ctl/src/rex/ctl/core.py", line 769, in _parse_argv
    attrs[opt.attr].append(value)
AttributeError: 'tuple' object has no attribute 'append'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/bin/rex", line 11, in <module>
    load_entry_point('rex.ctl', 'console_scripts', 'rex')()
  File "/app/src/rex.ctl/src/rex/ctl/core.py", line 632, in main
    raise exc_info[0](exc_info[1]).with_traceback(exc_info[2])
  File "/app/src/rex.ctl/src/rex/ctl/core.py", line 623, in main
    run(sys.argv)
  File "/app/src/rex.ctl/src/rex/ctl/core.py", line 975, in run
    task, attrs = _parse_argv(argv)
  File "/app/src/rex.ctl/src/rex/ctl/core.py", line 769, in _parse_argv
    attrs[opt.attr].append(value)
AttributeError: 'tuple' object has no attribute 'append'
```
