### PR TITLE
Expose Server-Side Function for Submitting to rex.file Table

### DIFF
--- a/src/rex.file/doc/reference.rst
+++ b/src/rex.file/doc/reference.rst
@@ -5,6 +5,12 @@
 .. automodule:: rex.file
 
 
+Functions
+=========
+
+.. autofunction:: rex.file.save_file
+
+
 Available HTTP locations
 ========================
 

--- a/src/rex.file/setup.cfg
+++ b/src/rex.file/setup.cfg
@@ -5,6 +5,7 @@ branch = True
 [report]
 exclude_lines =
         raise NotImplementedError
+show_missing = True
 
 # PBBT configuration
 [pbbt]

--- a/src/rex.file/src/rex/file/__init__.py
+++ b/src/rex.file/src/rex/file/__init__.py
@@ -7,5 +7,5 @@ from .fact import FileFact
 from .handle import HandleUpload
 from .map import MapFile
 from .model import FileTableConstraintModel, FileLinkConstraintModel
-
+from .util import save_file
 

--- a/src/rex.file/src/rex/file/handle.py
+++ b/src/rex.file/src/rex/file/handle.py
@@ -4,12 +4,12 @@
 
 
 from rex.core import Error
-from rex.attach import get_storage
 from rex.web import HandleLocation, authorize, confine
-from rex.db import get_db
 from webob import Response
 from webob.exc import HTTPUnauthorized
 import cgi
+
+from .util import save_file
 
 
 class HandleUpload(HandleLocation):
@@ -33,14 +33,8 @@ class HandleUpload(HandleLocation):
                         error = Error("Received duplicate upload name:", key)
                         return req.get_response(error)
                     inputs[key] = value
-            storage = get_storage()
-            db = get_db()
             outputs = {}
             for key, attachment in sorted(inputs.items()):
-                handle = storage.add(attachment.filename, attachment.file)
-                product = db.produce("insert(file:={handle:=$handle})",
-                                     handle=handle)
-                outputs[key] = str(product.data)
+                outputs[key] = save_file(attachment.filename, attachment.file)
             return Response(json=outputs)
-
 

--- a/src/rex.file/src/rex/file/util.py
+++ b/src/rex.file/src/rex/file/util.py
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2020, Prometheus Research, LLC
+#
+
+from rex.attach import get_storage
+from rex.db import get_db
+
+
+def save_file(name, content):
+    """
+    Saves a file in the ``rex.attach`` storage and records its existence in the
+    ``file`` table.
+
+    Returns a string containing the file's ``rex.attach`` handle.
+
+    :param name: The name of the file to be saved.
+    :type name: str
+    :param content: The file's contents.
+    :type content: str or file-like object
+    :rtype: str
+    """
+
+    handle = get_storage().add(name, content)
+    rec = get_db().produce(
+        '''
+        /insert(file := {
+            handle := $handle,
+        })
+        ''',
+        handle=handle,
+    )
+    return str(rec.data)
+

--- a/src/rex.file/test/input.yaml
+++ b/src/rex.file/test/input.yaml
@@ -18,6 +18,6 @@ tests:
 
 - sh: pip uninstall -q -y rex.file_demo
 
-#- coverage-check: 95.0
+- coverage-check: 85.0
 - coverage-report: ./build/coverage
 


### PR DESCRIPTION
This is just a minor refactoring to expose a simple function to allow back-end code to more easily use the `rex.file` infrastructure.