### PR TITLE
RexTask: remove optional 'project' argument

### DIFF
--- a/src/rex.assessment_import/test/test_ctl.rst
+++ b/src/rex.assessment_import/test/test_ctl.rst
@@ -21,7 +21,7 @@ to CSV files::
 
   >>> ctl('help assessment-template-export')
   ASSESSMENT-TEMPLATE-EXPORT - exports an InstrumentVersion from the datastore
-  Usage: rex assessment-template-export [<project>] <instrument-uid>
+  Usage: rex assessment-template-export <instrument-uid>
   <BLANKLINE>
   The assessment-template-export task will export an InstrumentVersion from a
   project's data store and save generated output in given format,
@@ -87,7 +87,7 @@ the bunch of csv files as Assessment objects to the datastore::
 
   >>> ctl('help assessment-import')
   ASSESSMENT-IMPORT - imports Assessment data given as a zip, bunch of csv or xls
-  Usage: rex assessment-import [<project>] <instrument-uid>
+  Usage: rex assessment-import <instrument-uid>
   <BLANKLINE>
   to the datastore.
   <BLANKLINE>

--- a/src/rex.asynctask/src/rex/asynctask/ctl.py
+++ b/src/rex.asynctask/src/rex/asynctask/ctl.py
@@ -15,7 +15,7 @@ from apscheduler.schedulers import SchedulerNotRunningError
 from apscheduler.schedulers.background import BackgroundScheduler
 
 from rex.core import get_settings, get_rex
-from rex.ctl import RexTask, option, env
+from rex.ctl import RexTaskWithProject, option, env
 from rex.logging import get_logger, disable_logging
 
 from .core import get_transport
@@ -27,7 +27,7 @@ __all__ = (
 )
 
 
-class AsyncTaskWorkerTask(RexTask):
+class AsyncTaskWorkerTask(RexTaskWithProject):
     """
     Launches processes for the rex.asynctask workers that are configured.
 

--- a/src/rex.ctl/README.rst
+++ b/src/rex.ctl/README.rst
@@ -126,18 +126,18 @@ variables::
     ...
 
 Another option is to specify the application name and configuration using
-command-line arguments and options::
+command-line parameters::
 
-    $ rex deploy rex.ctl_demo --set db=pgsql:ctl_demo
+    $ rex deploy --project rex.ctl_demo --set db=pgsql:ctl_demo
     ...
 
-    $ rex serve rex.ctl_demo --set db=pgsql:ctl_demo -h localhost -p 8088
+    $ rex serve --project rex.ctl_demo --set db=pgsql:ctl_demo -h localhost -p 8088
     ...
 
 To get a list of all configuration parameters supported by the application, use
 ``rex setting`` task, e.g.::
 
-    $ rex settings rex.ctl_demo
+    $ rex settings --project rex.ctl_demo
     access:
     db*:
       'pgsql:ctl_demo'
@@ -145,7 +145,7 @@ To get a list of all configuration parameters supported by the application, use
     gateways:
     ...
 
-    $ rex settings rex.ctl_demo --verbose
+    $ rex settings --project rex.ctl_demo --verbose
     [access]
     Declared in:
       rex.web
@@ -156,14 +156,14 @@ To get a list of all configuration parameters supported by the application, use
 To get a list of all packages that constitute the application, use ``rex
 packages`` task, e.g.::
 
-    $ rex packages rex.ctl_demo
+    $ rex packages --project rex.ctl_demo
     rex.ctl_demo == 1.7.0
     rex.port == 1.0.2
     rex.deploy == 2.0.0
     rex.db == 3.0.0
     ...
 
-    $ rex packages rex.ctl_demo --verbose
+    $ rex packages --project rex.ctl_demo --verbose
     [rex.ctl_demo]
     Version:
       1.7.0
@@ -176,7 +176,7 @@ packages`` task, e.g.::
 To interact with the application from Python shell, use ``rex pyshell`` task,
 e.g.::
 
-    $ rex pyshell rex.ctl_demo
+    $ rex pyshell --project rex.ctl_demo
     Type 'help' for more information, Ctrl-D to exit.
 
 .. highlight:: python
@@ -585,6 +585,4 @@ Finally, let's look at ``rex demo-user-add``::
 This task has two arguments ``<code>`` and ``<name>`` and a toggle
 ``--disabled``.  Their values are stored as attributes ``self.code``,
 ``self.name`` and ``self.disabled`` on the task instance.
-
-
 

--- a/src/rex.ctl/doc/reference.rst
+++ b/src/rex.ctl/doc/reference.rst
@@ -25,6 +25,7 @@ Template for application-specific tasks
 =======================================
 
 .. autoclass:: rex.ctl.RexTask
+.. autoclass:: rex.ctl.RexTaskWithProject
 
 
 Loading application from ``rex.yaml``

--- a/src/rex.ctl/src/rex/ctl/__init__.py
+++ b/src/rex.ctl/src/rex/ctl/__init__.py
@@ -13,9 +13,10 @@ from .core import (
         debug, warn, fail, prompt, run, main, Task, Global, Topic)
 from .fs import cp, mv, rm, rmtree, mktree, exe, sh, pipe
 from .std import (
-        HelpTask, UsageTask, RexTask, DebugGlobal, ConfigGlobal, ProjectGlobal,
-        RequirementsGlobal, ParametersGlobal, SentryGlobal, PackagesTask,
-        SettingsTask, PyShellTask, ConfigurationTopic, load_rex)
+        HelpTask, UsageTask, RexTask, RexTaskWithProject, DebugGlobal,
+        ConfigGlobal, ProjectGlobal, RequirementsGlobal, ParametersGlobal,
+        SentryGlobal, PackagesTask, SettingsTask, PyShellTask,
+        ConfigurationTopic, load_rex)
 from .ctl import Ctl, ctl
 
 

--- a/src/rex.ctl/test/test_ctl.rst
+++ b/src/rex.ctl/test/test_ctl.rst
@@ -33,10 +33,10 @@ To get help on task parameters, run ``rex help <task>``::
     Run rex hello to greet the current user.  Alternatively,
     run rex hello <name> to greet the specified user.
 
-To run an application-specific command, you need to configure the application.
-One option is to pass the application name on the command line::
+To run an application-specific command, you need to specify the application
+using a global object ``--project``::
 
-    >>> ctl("demo-init rex.ctl_demo")           # doctest: +NORMALIZE_WHITESPACE
+    >>> ctl("demo-init --project=rex.ctl_demo")         # doctest: +NORMALIZE_WHITESPACE
     Creating database pgsql:///ctl_demo.
     Deploying application database to pgsql:///ctl_demo.
     Deploying rex.ctl_demo.
@@ -57,7 +57,7 @@ package is specified::
     >>> ctl("demo-user-list", expect=1)         # doctest: +NORMALIZE_WHITESPACE
     FATAL ERROR: application is not specified
 
-    >>> ctl("demo-user-list rex.ctl", expect=1) # doctest: +NORMALIZE_WHITESPACE
+    >>> ctl("demo-user-list --project=rex.ctl", expect=1)   # doctest: +NORMALIZE_WHITESPACE
     FATAL ERROR: package rex.ctl_demo must be included with the application
 
 To get a list of packages that compose the application, use ``rex packages``::
@@ -85,11 +85,12 @@ To get a list of packages that compose the application, use ``rex packages``::
 Application parameters could be specified using option ``--set`` or global
 option ``--parameters``::
 
-    >>> ctl("demo-user-list rex.ctl_demo --set db=pgsql:ctl_demo")  # doctest: +NORMALIZE_WHITESPACE
+    >>> ctl("demo-user-list --project rex.ctl_demo"
+    ...     " --set db=pgsql:ctl_demo")  # doctest: +NORMALIZE_WHITESPACE
     Alice Amter (alice@rexdb.com)
     Bob Barker (bob@rexdb.com)
 
-    >>> ctl("demo-user-list rex.ctl_demo"
+    >>> ctl("demo-user-list --project rex.ctl_demo"
     ...     " --parameters '{\"db\": \"pgsql:ctl_demo\"}'")         # doctest: +NORMALIZE_WHITESPACE
     Alice Amter (alice@rexdb.com)
     Bob Barker (bob@rexdb.com)

--- a/src/rex.db/src/rex/db/ctl.py
+++ b/src/rex.db/src/rex/db/ctl.py
@@ -57,7 +57,7 @@ class RexDBTask(RexTask):
                 value_name="NAME",
                 hint="connect to a gateway database")
 
-    def make(self, extra_requirements=[], extra_parameters={}, *args, **kwds):
+    def make(self, project=None, extra_requirements=[], extra_parameters={}, *args, **kwds):
         # Converts and merges `--extend` to `htsql_extension` parameter.
         htsql_extensions = []
         htsql_extensions.append(env.parameters.get('htsql_extensions', {}))
@@ -68,7 +68,7 @@ class RexDBTask(RexTask):
             extra_parameters = extra_parameters.copy()
             extra_parameters['htsql_extensions'] = htsql_extensions
         return super(RexDBTask, self).make(
-                extra_requirements, extra_parameters, *args, **kwds)
+                project, extra_requirements, extra_parameters, *args, **kwds)
 
     def get_db(self):
         # Gets the HTSQL instance, possibly for a gateway database.

--- a/src/rex.deploy/src/rex/deploy/ctl.py
+++ b/src/rex.deploy/src/rex/deploy/ctl.py
@@ -3,12 +3,12 @@
 #
 
 
-from rex.core import get_settings, Error
-from rex.ctl import RexTask, argument, option, env, log, fail, warn, debug, exe
+from rex.core import get_settings, Error, StrVal
+from rex.ctl import RexTaskWithProject, option, env, log, fail, warn, debug, exe
 from .cluster import get_cluster, deploy
 
 
-class CreateDBTask(RexTask):
+class CreateDBTask(RexTaskWithProject):
     """create application database"""
 
     name = 'createdb'
@@ -28,7 +28,7 @@ class CreateDBTask(RexTask):
                 cluster.create()
 
 
-class DropDBTask(RexTask):
+class DropDBTask(RexTaskWithProject):
     """delete application database"""
 
     name = 'dropdb'
@@ -48,7 +48,7 @@ class DropDBTask(RexTask):
                 cluster.drop()
 
 
-class DumpDBTask(RexTask):
+class DumpDBTask(RexTaskWithProject):
     """dump application database to a file"""
 
     name = 'dumpdb'
@@ -88,7 +88,7 @@ class DumpDBTask(RexTask):
         exe(command)
 
 
-class LoadDBTask(RexTask):
+class LoadDBTask(RexTaskWithProject):
     """load application database from a file"""
 
     name = 'loaddb'
@@ -134,7 +134,7 @@ class LoadDBTask(RexTask):
         exe(command)
 
 
-class DeployTask(RexTask):
+class DeployTask(RexTaskWithProject):
     """deploy database schema
 
     Use ``deploy`` task to create and populate the application

--- a/src/rex.forms/README.rst
+++ b/src/rex.forms/README.rst
@@ -205,7 +205,7 @@ be installed and referenced by the project or ``rex.yaml``.
 
 ::
 
-    rex forms-retrieve <instrument-uid> <channel-uid> [<project>]
+    rex forms-retrieve <instrument-uid> <channel-uid>
 
 
 forms-store
@@ -224,7 +224,7 @@ be installed and referenced by the project or ``rex.yaml``.
 
 ::
 
-    rex forms-store <instrument-uid> <channel-uid> <configuration> [<project>]
+    rex forms-store <instrument-uid> <channel-uid> <configuration>
 
 
 forms-validate

--- a/src/rex.forms/test/test_ctl.rst
+++ b/src/rex.forms/test/test_ctl.rst
@@ -201,7 +201,7 @@ from a Form in the project data store::
 
     >>> ctl('help forms-retrieve')
     FORMS-RETRIEVE - retrieves a Form from the datastore
-    Usage: rex forms-retrieve [<project>] <instrument-uid> <channel-uid>
+    Usage: rex forms-retrieve <instrument-uid> <channel-uid>
     <BLANKLINE>
     The forms-retrieve task will retrieve a Form from a project's data store
     and return the Web Form Configuration.
@@ -370,7 +370,7 @@ in the project data store::
 
     >>> ctl('help forms-store')
     FORMS-STORE - stores a Form in the data store
-    Usage: rex forms-store [<project>] <instrument-uid> <channel-uid> <configuration>
+    Usage: rex forms-store <instrument-uid> <channel-uid> <configuration>
     <BLANKLINE>
     The forms-store task will write a Web Form Configuration file to a Form in
     the project's data store.

--- a/src/rex.graphql/demo/src/rex/graphql_demo.py
+++ b/src/rex.graphql/demo/src/rex/graphql_demo.py
@@ -4,7 +4,7 @@ import collections
 import urllib.request, urllib.parse, urllib.error
 import csv
 
-from rex.ctl import RexTask, option, log
+from rex.ctl import RexTaskWithProject, option, log
 from rex.db import get_db
 from rex.web import HandleLocation
 from rex.core import cached
@@ -92,7 +92,7 @@ class API(HandleLocation):
         return serve(self.schema(), req)
 
 
-class PopulateTask(RexTask):
+class PopulateTask(RexTaskWithProject):
     """populate the demo database"""
 
     name = "graphql-demo-populate"

--- a/src/rex.instrument/README.rst
+++ b/src/rex.instrument/README.rst
@@ -161,7 +161,7 @@ be installed and referenced by the project or ``rex.yaml``.
 
 ::
 
-  rex instrument-retrieve <instrument-uid> [<project>]
+  rex instrument-retrieve <instrument-uid>
 
 
 instrument-store
@@ -179,7 +179,7 @@ be installed and referenced by the project or ``rex.yaml``.
 
 ::
 
-  rex instrument-store <instrument-uid> <definition> [<project>]
+  rex instrument-store <instrument-uid> <definition>
 
 
 instrument-validate
@@ -221,7 +221,7 @@ be installed and referenced by the project or ``rex.yaml``.
 
 ::
 
-  rex calculationset-retrieve <instrument-uid> [<project>]
+  rex calculationset-retrieve <instrument-uid>
 
 
 calculationset-store
@@ -238,7 +238,7 @@ be installed and referenced by the project or ``rex.yaml``.
 
 ::
 
-  rex calculationset-store <instrument-uid> <definition> [<project>]
+  rex calculationset-store <instrument-uid> <definition>
 
 
 calculationset-validate

--- a/src/rex.instrument/test/test_ctl.rst
+++ b/src/rex.instrument/test/test_ctl.rst
@@ -155,7 +155,7 @@ Definition JSON from an InstrumentVersion in the project data store::
 
     >>> ctl('help instrument-retrieve')
     INSTRUMENT-RETRIEVE - retrieves an InstrumentVersion from the datastore
-    Usage: rex instrument-retrieve [<project>] <instrument-uid>
+    Usage: rex instrument-retrieve <instrument-uid>
     <BLANKLINE>
     The instrument-retrieve task will retrieve an InstrumentVersion from a
     project's data store and return the Common Instrument Definition.
@@ -261,7 +261,7 @@ to an InstrumentVersion in the project data store::
 
     >>> ctl('help instrument-store')
     INSTRUMENT-STORE - stores an InstrumentVersion in the data store
-    Usage: rex instrument-store [<project>] <instrument-uid> <definition>
+    Usage: rex instrument-store <instrument-uid> <definition>
     <BLANKLINE>
     The instrument-store task will write a Common Instrument Definition file to
     an InstrumentVersion in the project's data store.
@@ -442,7 +442,7 @@ way specified::
 
     >>> ctl('help calculationset-format')
     CALCULATIONSET-FORMAT - render a Common CalculationSet Definition into various formats
-    Usage: rex calculationset-format [<project>] <definition>
+    Usage: rex calculationset-format <definition>
     <BLANKLINE>
     The calculationset-format task will take an input Common CalculationSet
     Definition file and output it as either JSON or YAML.
@@ -571,7 +571,7 @@ Definition JSON from an InstrumentVersion in the project data store::
 
     >>> ctl('help calculationset-retrieve')
     CALCULATIONSET-RETRIEVE - retrieves an CalculationSet from the datastore
-    Usage: rex calculationset-retrieve [<project>] <instrument-uid>
+    Usage: rex calculationset-retrieve <instrument-uid>
     <BLANKLINE>
     The calculation-retrieve task will retrieve an CalculationSet from a
     project's data store and return the Common CalculationSet Definition.
@@ -694,7 +694,7 @@ to an InstrumentVersion in the project data store::
 
     >>> ctl('help calculationset-store')
     CALCULATIONSET-STORE - stores an CalculationSet in the data store
-    Usage: rex calculationset-store [<project>] <instrument-uid> <definition>
+    Usage: rex calculationset-store <instrument-uid> <definition>
     <BLANKLINE>
     The calculationset-store task will write a Common CalculationSet Definition
     file to an CalculationSet in the project's data store.

--- a/src/rex.mart/test/test_ctl.rst
+++ b/src/rex.mart/test/test_ctl.rst
@@ -38,7 +38,7 @@ command line::
 
     >>> ctl('help mart-create')
     MART-CREATE - create Mart database(s)
-    Usage: rex mart-create [<project>]
+    Usage: rex mart-create
     <BLANKLINE>
     The mart-create task will create the specified Mart databases. You specify
     the Marts to create by either using a combination of the --owner and
@@ -278,7 +278,7 @@ The ``mart-shell`` task opens an HTSQL console to the specified Mart database::
 
     >>> ctl('help mart-shell')
     MART-SHELL - open HTSQL shell to Mart database
-    Usage: rex mart-shell [<project>] <code-name-owner>
+    Usage: rex mart-shell <code-name-owner>
     <BLANKLINE>
     The mart-shell task opens an HTSQL shell to the specified Mart database.
     <BLANKLINE>
@@ -355,7 +355,7 @@ The ``mart-purge`` will delete the specified Mart(s) from the system::
 
     >>> ctl('help mart-purge')
     MART-PURGE - purge Mart database(s)
-    Usage: rex mart-purge [<project>]
+    Usage: rex mart-purge
     <BLANKLINE>
     The mart-purge task will delete the specified Mart databases from the
     system.

--- a/src/rex.mobile/README.rst
+++ b/src/rex.mobile/README.rst
@@ -89,7 +89,7 @@ be installed and referenced by the project or ``rex.yaml``.
 
 ::
 
-    rex mobile-retrieve <instrument-uid> <channel-uid> [<project>]
+    rex mobile-retrieve <instrument-uid> <channel-uid>
 
 
 mobile-store
@@ -108,7 +108,7 @@ be installed and referenced by the project or ``rex.yaml``.
 
 ::
 
-    rex mobile-store <instrument-uid> <channel-uid> <configuration> [<project>]
+    rex mobile-store <instrument-uid> <channel-uid> <configuration>
 
 
 mobile-validate

--- a/src/rex.mobile/test/test_ctl.rst
+++ b/src/rex.mobile/test/test_ctl.rst
@@ -192,7 +192,7 @@ JSON from a Form in the project data store::
 
     >>> ctl('help mobile-retrieve')
     MOBILE-RETRIEVE - retrieves an Interaction from the datastore
-    Usage: rex mobile-retrieve [<project>] <instrument-uid> <channel-uid>
+    Usage: rex mobile-retrieve <instrument-uid> <channel-uid>
     <BLANKLINE>
     The mobile-retrieve task will retrieve an Interaction from a project's data
     store and return the SMS Interaction Configuration.
@@ -353,7 +353,7 @@ a Form in the project data store::
 
     >>> ctl('help mobile-store')
     MOBILE-STORE - stores an Interaction in the data store
-    Usage: rex mobile-store [<project>] <instrument-uid> <channel-uid> <configuration>
+    Usage: rex mobile-store <instrument-uid> <channel-uid> <configuration>
     <BLANKLINE>
     The mobile-store task will write an SMS Interaction Configuration file to
     an Interaction in the project's data store.

--- a/src/rex.query/demo/src/rex/query_demo.py
+++ b/src/rex.query/demo/src/rex/query_demo.py
@@ -3,7 +3,7 @@ import tempfile
 import urllib.request, urllib.parse, urllib.error
 import csv
 
-from rex.ctl import RexTask, option, log
+from rex.ctl import RexTaskWithProject, option, log
 from rex.db import get_db
 from rex.query import RenderApp
 
@@ -17,7 +17,7 @@ class RenderQueryDemo(RenderApp):
     path = '/'
 
 
-class PopulateTask(RexTask):
+class PopulateTask(RexTaskWithProject):
     """populate the demo database"""
 
     name = 'query-demo-populate'

--- a/src/rex.storage/src/rex/storage/ctl.py
+++ b/src/rex.storage/src/rex/storage/ctl.py
@@ -1,12 +1,12 @@
 
 import os
 from pathlib import Path
-from rex.ctl import RexTask, argument, log, fail
+from rex.ctl import RexTaskWithProject, argument, log, fail
 from rex.core import StrVal
 from .storage import get_storage
 
 
-class Upload(RexTask):
+class Upload(RexTaskWithProject):
     """
     Uploads local files to the external storage.
     """

--- a/src/rex.tabular_import/test/test_ctl.rst
+++ b/src/rex.tabular_import/test/test_ctl.rst
@@ -16,7 +16,7 @@ the specified table::
 
     >>> ctl('help tabular-import-template')
     TABULAR-IMPORT-TEMPLATE - creates a template file that can be used with the tabular-import task
-    Usage: rex tabular-import-template [<project>] <table>
+    Usage: rex tabular-import-template <table>
     <BLANKLINE>
     The tabular-import-template task will create a template file that contains
     a skeleton structure and field information about the table you wish to
@@ -60,7 +60,7 @@ in the database::
 
     >>> ctl('help tabular-import')
     TABULAR-IMPORT - loads records from a flat file into a table in the database
-    Usage: rex tabular-import [<project>] <table> <data>
+    Usage: rex tabular-import <table> <data>
     <BLANKLINE>
     The tabular-import task will take the records described in a flat file
     (generally one based on a template from the tabular-import-template task)

--- a/src/rex.web/src/rex/web/ctl.py
+++ b/src/rex.web/src/rex/web/ctl.py
@@ -8,7 +8,8 @@ from rex.core import (
         get_packages, get_settings, Error, PythonPackage, StrVal, PIntVal,
         BoolVal, MaybeVal, MapVal, Validate)
 from rex.ctl import (
-        env, RexTask, Global, Topic, argument, option, log, fail, exe, COLORS)
+        env, RexTaskWithProject, Global, Topic, argument, option, log, fail,
+        exe, COLORS)
 import sys
 import os
 import time
@@ -226,7 +227,7 @@ class ReplayLogGlobal(Global):
     default = None
 
 
-class RexWatchTask(RexTask):
+class RexWatchTask(RexTaskWithProject):
     # Provides automatic watch daemon for the application.
 
     class options:
@@ -253,7 +254,7 @@ class RexWatchTask(RexTask):
         return self.make(*args, **kwds)
 
 
-class WatchTask(RexTask):
+class WatchTask(RexTaskWithProject):
     """start watchers to rebuild generated files on source changes
 
     The `watch` task starts watchers to rebuild generated files on source
@@ -373,7 +374,7 @@ class ServeTask(RexWatchTask):
                 process.wait()
 
 
-class WSGITask(RexTask):
+class WSGITask(RexTaskWithProject):
     """generate a WSGI script
 
     The `wsgi` task generates a WSGI script for a RexDB application, which
@@ -603,7 +604,7 @@ class StartTask(RexWatchTask):
                        subprocess.list2cmdline(cmd))
 
 
-class StopTask(RexTask):
+class StopTask(RexTaskWithProject):
     """stop a running uWSGI daemon
 
     The `stop` task stops a uWSGI server running in daemon mode.
@@ -651,7 +652,7 @@ class StopTask(RexTask):
             os.unlink(form.pid_path)
 
 
-class StatusTask(RexTask):
+class StatusTask(RexTaskWithProject):
     """check if a uWSGI daemon is running
 
     The `status` task verifies if there is an active UWSGI server
@@ -801,7 +802,7 @@ class ReplayHandler:
             log("ERRORS: :warning:`{}`", self.errors)
 
 
-class ReplayTask(RexTask):
+class ReplayTask(RexTaskWithProject):
     """replay WSGI requests from the log"""
 
     name = 'replay'


### PR DESCRIPTION
This is a backward-incompatible change:
- Removed optional `project` argument for `RexTask`.
- To avoid breaking existing tests, added `project` to the tasks that use this argument in the test suite. This is implemented in `rex.ctl.RexTaskWithProject`.
