### PR TITLE
rex.attach: fix download with GCS backend under uWSGI

### DIFF
--- a/kube.yml
+++ b/kube.yml
@@ -1,5 +1,11 @@
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: develop
+
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: develop
@@ -62,6 +68,7 @@ metadata:
   labels:
     app: develop
 spec:
+  serviceAccountName: develop
   volumes:
   - name: appenv
     emptyDir: {}

--- a/src/rex.attach/src/rex/attach.py
+++ b/src/rex.attach/src/rex/attach.py
@@ -64,7 +64,7 @@ class OpenFileApp:
 
     def __call__(self, req):
         # Adapted from `FileApp.__call__()`.
-        if 'wsgi.file_wrapper' in req.environ:
+        if 'wsgi.file_wrapper' in req.environ and not isinstance(self.file, io.BytesIO):
             app_iter = req.environ['wsgi.file_wrapper'](self.file, BLOCK_SIZE)
         else:
             app_iter = FileIter(self.file)

--- a/src/rex.attach/src/rex/attach.py
+++ b/src/rex.attach/src/rex/attach.py
@@ -658,7 +658,9 @@ class InitializeAttach(Initialize):
     # Verifies that the attachment storage is configured correctly.
 
     def __call__(self):
-        storage = get_storage()
+        # Avoid caching the storage object during initialization since
+        # it triggers SSL error with GCS backend and uwsgi.processes > 1.
+        storage = get_storage.__wrapped__()
         storage.verify()
 
 


### PR DESCRIPTION
Fixes the error on downloading an attachment. This error is triggered when the application runs under uWSGI and the attachment storage uses GCS backend:
```
io.UnsupportedOperation: fileno

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/src/rex.core/src/rex/core/application.py", line 98, in __call__
    output = wsgi(environ, start_response)
  File "/app/src/rex.web/src/rex/web/route.py", line 525, in __call__
    resp = self.handler(req)
  File "/app/src/rex.web/src/rex/web/route.py", line 169, in __call__
    resp = self.handle(req)
  File "/app/src/rex.web/src/rex/web/route.py", line 202, in __call__
    return self.handle(req)
  File "/app/src/rex.db/src/rex/db/database.py", line 210, in __call__
    return self.handle(req)
  File "/app/src/rex.web/src/rex/web/route.py", line 238, in __call__
    return route(req)
  File "/app/src/rex.web/src/rex/web/route.py", line 268, in __call__
    return handle(req)
  File "/app/src/rex.web/src/rex/web/route.py", line 388, in __call__
    return handler(req)
  File "/app/src/rex.web/src/rex/web/command.py", line 86, in __call__
    return self.render(req, **arguments)
  File "/app/src/rex.attach/demo/src/rex/attach_demo.py", line 56, in render
    return download(handle)(req)
  File "/app/src/rex.attach/src/rex/attach.py", line 69, in __call__
    app_iter = req.environ['wsgi.file_wrapper'](self.file, BLOCK_SIZE)
SystemError: <built-in function uwsgi_sendfile> returned a result with an error set
```
It also fixes an occasional SSL error with GCS backend when `uwsgi.processes > 1`:
```
ssl.SSLError: [SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC] decryption failed or bad record mac (_ssl.c:2309)
```
In addition, this PR adds a dedicated Kubernetes service account for the development pod. This is to make it easier to grant it permissions for using GCP API.