### PR TITLE
Storage: Fixed issues with object list/tree

### DIFF
--- a/src/rex.storage/src/rex/storage/storage.py
+++ b/src/rex.storage/src/rex/storage/storage.py
@@ -1,4 +1,3 @@
-
 import io
 import os.path
 import tempfile
@@ -458,14 +457,12 @@ class Storage:
         :type storage_path: str|rex.storage.Path
         :rtype: iter(rex.storage.Path)
         """
-
         path = self.parse_path(storage_path)
-        mount_root = path.container_location.lstrip('/')
+        mount_root = path.mount.base_path.lstrip('/')
         for blob in path.mount.container:
-            if not mount_root:
-                yield path.join(blob.name)
-            elif blob.name.startswith(mount_root):
-                yield path.join(blob.name[len(mount_root):])
+            if not blob.name.startswith(path.container_location):
+                continue
+            yield path.mount.path(blob.name[len(mount_root):])
 
     def object_tree(self, storage_path):
         """
@@ -479,8 +476,13 @@ class Storage:
 
         tree = {}
 
+        storage_path = self.parse_path(storage_path)
+        prefix_len = len(storage_path.name)
+        if prefix_len:
+            prefix_len += 1
+
         for path in self.object_list(storage_path):
-            parts = path.name.split('/')
+            parts = path.name[prefix_len:].split('/')
 
             scope = tree
             while parts:
@@ -494,4 +496,3 @@ class Storage:
                     scope[part] = path
 
         return tree
-

--- a/src/rex.storage/test/test_local_driver.py
+++ b/src/rex.storage/test/test_local_driver.py
@@ -78,8 +78,8 @@ def test_object_list():
         for obj in get_storage().object_list('/other-p/dir2')
     ])
     assert objects == [
-        '4.txt',
-        '5.txt',
+        'dir2/4.txt',
+        'dir2/5.txt',
     ]
 
 
@@ -112,7 +112,7 @@ def test_object_tree():
         get_storage().object_tree('/other-p/dir2')
     )
     assert tree == \
-        {'4.txt': '4.txt', '5.txt': '5.txt'}
+        {'4.txt': 'dir2/4.txt', '5.txt': 'dir2/5.txt'}
 
 
 def test_exists():

--- a/src/rex.storage/test/test_rex_driver.py
+++ b/src/rex.storage/test/test_rex_driver.py
@@ -35,9 +35,9 @@ def test_object_list():
         for obj in get_storage().object_list('/rst/stuff')
     ])
     assert objects == [
-        'bar',
-        'foo',
-        'subdir/baz',
+        'stuff/bar',
+        'stuff/foo',
+        'stuff/subdir/baz',
     ]
 
     objects = sorted([
@@ -70,10 +70,10 @@ def test_object_tree():
         get_storage().object_tree('/rst/stuff')
     )
     assert tree == {
-        'bar': 'bar',
-        'foo': 'foo',
+        'bar': 'stuff/bar',
+        'foo': 'stuff/foo',
         'subdir/': {
-            'baz': 'subdir/baz',
+            'baz': 'stuff/subdir/baz',
         },
     }
 


### PR DESCRIPTION
- `object_list()` would produce incorrect paths for found objects when searching paths other than root.
- `object_tree()` now returns the full object path as the value for files in the dict.