### PR TITLE
deploy: add support for managing SQL views

### DIFF
--- a/src/rex.deploy/src/rex/deploy/meta.py
+++ b/src/rex.deploy/src/rex/deploy/meta.py
@@ -7,7 +7,7 @@ from rex.core import (
         Location, set_location, UStrVal, UChoiceVal, MaybeVal, SeqVal,
         RecordVal, Error)
 from .fact import LabelVal, TitleVal, AliasVal, AliasSpec, FactDumper
-from .image import TableImage, ColumnImage, UniqueKeyImage
+from .image import TableImage, ViewImage, ColumnImage, UniqueKeyImage
 import operator
 import collections
 import yaml
@@ -133,6 +133,17 @@ class TableMeta(Meta):
     ]
 
 
+class ViewMeta(Meta):
+    """View metadata."""
+
+    __slots__ = ()
+
+    fields = [
+            ('label', LabelVal, None),
+            ('title', TitleVal, None),
+    ]
+
+
 class ColumnMeta(Meta):
     """Column metadata."""
 
@@ -162,6 +173,8 @@ def uncomment(image):
     """
     if isinstance(image, TableImage):
         return TableMeta.parse(image.comment)
+    if isinstance(image, ViewImage):
+        return ViewMeta.parse(image.comment)
     elif isinstance(image, ColumnImage):
         return ColumnMeta.parse(image.comment)
     elif isinstance(image, UniqueKeyImage) and image.is_primary:

--- a/src/rex.deploy/src/rex/deploy/sql.py
+++ b/src/rex.deploy/src/rex/deploy/sql.py
@@ -288,6 +288,33 @@ def sql_comment_on_table(qname, text):
     COMMENT ON TABLE {{ qname|qn }} IS {{ text|v }};
     """
 
+@sql_template
+def sql_create_view(qname, definition):
+    """
+    CREATE VIEW {{ qname|qn }} AS ({{ definition }});
+    """
+
+
+@sql_template
+def sql_drop_view(qname):
+    """
+    DROP VIEW {{ qname|qn }};
+    """
+
+
+@sql_template
+def sql_rename_view(qname, new_name):
+    """
+    ALTER VIEW {{ qname|qn }} RENAME TO {{ new_name|n }};
+    """
+
+
+@sql_template
+def sql_comment_on_view(qname, text):
+    """
+    COMMENT ON VIEW {{ qname|qn }} IS {{ text|v }};
+    """
+
 
 @sql_template
 def sql_define_column(name, type_qname, is_not_null, default=None):

--- a/src/rex.deploy/test/test_view.rst
+++ b/src/rex.deploy/test/test_view.rst
@@ -1,0 +1,104 @@
+*******************
+  Deploying views
+*******************
+
+.. contents:: Table of Contents
+
+Parsing view record
+===================
+
+We start with creating a test database and a ``Driver`` instance::
+
+    >>> from rex.deploy import Cluster
+    >>> cluster = Cluster('pgsql:deploy_demo_view')
+    >>> cluster.overwrite()
+    >>> driver = cluster.drive(logging=True)
+
+Field ``view`` denotes a table fact::
+
+    >>> fact = driver.parse("""{ view: one, definition: "select 1 as n" }""")
+
+    >>> fact
+    ViewFact('one', definition='select 1 as n')
+    >>> print(fact)
+    view: one
+    definition: select 1 as n
+
+Creating the view
+=================
+
+Deploying a view fact creates the view::
+
+    >>> driver("""{ view: one, definition: "select 1 as n" }""")
+    CREATE VIEW "one" AS (select 1 as n);
+
+    >>> schema = driver.get_schema()
+    >>> 'one' in schema
+    True
+
+Deploying the same fact second time has no effect::
+
+    >>> driver("""{ view: one, definition: "select 1 as n" }""")
+
+Renaming the view
+=================
+
+Deploying a view fact with ``was`` and another name will rename the view::
+
+    >>> driver("""{ view: one2, was: one}""")
+    ALTER VIEW "one" RENAME TO "one2";
+
+Altering view definition
+========================
+
+Deploying a view fact with another definition will re-create the view::
+
+    >>> driver("""{ view: one2, definition: "select 2 as n" }""")
+    DROP VIEW "one2";
+    CREATE VIEW "one2" AS (select 2 as n);
+
+Deploying the same fact second time has no effect::
+
+    >>> driver("""{ view: one2, definition: "select 2 as n" }""")
+
+Dropping the view
+=================
+
+You can use ``ViewFact`` to remove a view::
+
+    >>> driver("""{ view: one2, present: false }""")
+    DROP VIEW "one2";
+
+Deploying the same fact second time has no effect::
+
+    >>> driver("""{ view: one2, present: false }""")
+
+Views which depend on one another
+=================================
+
+Let's create another view which uses the original ``one`` view in its
+definition::
+
+    >>> driver("""
+    ... - view: one
+    ...   definition: select 1 as n
+    ... - view: one_plus
+    ...   definition: select n + 1 from one
+    ... """)
+    CREATE VIEW "one" AS (select 1 as n);
+    CREATE VIEW "one_plus" AS (select n + 1 from one);
+
+Now we can try altering the ``one`` view which has dependents::
+
+    >>> driver("""{ view: one, definition: "select 2 as n" }""") # doctest: +ELLIPSIS
+    ...
+    Traceback (most recent call last):
+    ...
+    rex.core.Error: Got an error from the database driver:
+        cannot drop view one because other objects depend on it
+        DETAIL:  view one_plus depends on view one
+        HINT:  Use DROP ... CASCADE to drop the dependent objects too.
+    While executing SQL:
+        DROP VIEW "one";
+    While deploying view fact:
+        "<unicode string>", line 1


### PR DESCRIPTION
This PR takes a stab at implementing support for managing SQL views with rex.deploy.

The example usage:

```
- view: persons
  definition: |
    select name, email
    from user

- view: persons
  definition: |
    select name, email
    from user
    union
    select name, email
    from patient

- view: persons
  present: false
```

I've been trying to follow the code for tables but of course making this specific to the views.

Some notes/design questions appeared:

- How things are introspected has changed, previously both tables and views were loaded as TableImage objects. Now we load views as ViewImage objects and we DON'T load view columns. I suspect this will make a different when querying views with HTSQL?

- When building a model out of facts we need to check for name clashes between tables and views as they share the same namespace in the database.

- Should we raise an error in case the same named view appears with different definitions? Or should we instead override the former with the latter (dangerous)?

- Right now we load view definition with `pg_get_viewdef` function but I'm not sure if it is suitable for comparison with view definition in facts as db can probably mangle the original SQL. We should probably store view definition in a COMMENT in a database.

- Do we need to support view defined with HTSQL? That would be cool.

- Would be nice to be able to specify a pk for a view (required for HTSQL to query such view).

- We need to track dependencies:

  As we use SQL for view definitions we might need to use SQL parser for that. I'm thinking of using https://pglast.readthedocs.io/en/latest/ which wraps PostgreSQL's parser.

  If we want to add HTSQL based view then we can use HTSQL to infer the dependencies.

  - view -> table, why?

    - So we can require to drop view before we drop the table. It is implemented for linked tables? Would be nice as it will allow to validate migrations w/o accessing a database.

  - view -> view, why?

    - so we can require to drop dependent views before we drop the view

    - so we can change definition of a view with dependents (in this case we need to drop and re-create a view and its dependents)
