### PR TITLE
rex.widget: fix autocomplete widget lookup

### DIFF
--- a/src/rex.widget/src/rex/widget/formfield.py
+++ b/src/rex.widget/src/rex/widget/formfield.py
@@ -1002,7 +1002,7 @@ class AutocompleteField(Widget, PortSupport):
             'select': ['id'] + self._data.select,
             'with': [{
                 'calculation': 'title',
-                'expression': self._data.title
+                'expression': f'text({self._data.title})'
             }],
         }
         if masked and self._data.mask:

--- a/src/rex.widget/test/formfield/test_entity.rst
+++ b/src/rex.widget/test/formfield/test_entity.rst
@@ -44,7 +44,7 @@ Field configured to use autocomplete::
   select: []
   with:
   - calculation: title
-    expression: identity.givenname
+    expression: text(identity.givenname)
   ''')
 
   >>> widget.title_port
@@ -53,7 +53,7 @@ Field configured to use autocomplete::
   select: []
   with:
   - calculation: title
-    expression: identity.givenname
+    expression: text(identity.givenname)
   ''')
 
 Field configured to use radio button group::

--- a/src/rex.widget/test/formfield/test_index.rst
+++ b/src/rex.widget/test/formfield/test_index.rst
@@ -368,7 +368,7 @@ Enrich field from port
   select: []
   with:
   - calculation: title
-    expression: id()
+    expression: text(id())
   ''')
 
   >>> test_enrich('individual', """
@@ -392,7 +392,7 @@ Enrich field from port
   select: [id]
   with:
   - calculation: title
-    expression: title
+    expression: text(title)
   ''')
 
   >>> fields[0].widget().query_port.produce()


### PR DESCRIPTION
title default to id expression and if this id expression is not a text then `~` operator will fail.
