### PR TITLE
rex.sms: retry on 429 Too Many Requests

### DIFF
--- a/src/rex.sms/src/rex/sms/provider/twilioapi.py
+++ b/src/rex.sms/src/rex/sms/provider/twilioapi.py
@@ -76,7 +76,8 @@ class TwilioSmsProvider(SmsProvider):
                 return
 
             except TwilioRestException as exc:
-                if exc.status >= 500:
+                # Retry on 5XX or 429 Too Many Requests
+                if exc.status >= 500 or exc.status == 429:
                     if attempts < get_settings().sms_twilio_max_attempts:
                         time.sleep(retry_delay)
                     else:

--- a/src/rex.sms/test/test_twilio.rst
+++ b/src/rex.sms/test/test_twilio.rst
@@ -60,6 +60,24 @@ times before raising the exception::
     >>> mockTwilio.messages.create.call_count
     3
 
+We handle 429 Too Many Requests error the same way by retrying::
+
+    >>> def twilio_fail(*args, **kwargs):
+    ...     raise TwilioRestException(429, 'http://fake')
+    >>> mockTwilio = MagicMock()
+    >>> mockTwilio.messages.create.side_effect = twilio_fail
+    >>> get_sms_provider().client = mockTwilio
+
+    >>> send_sms('2035551234', '8002223333', 'hello world')  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+      ...
+    twilio.base.exceptions.TwilioRestException: ...
+
+    >>> mockTwilio.messages.create.call_count
+    3
+
+Other erorrs are raised without a retry::
+
     >>> def twilio_fail(*args, **kwargs):
     ...     raise TwilioRestException(401, 'http://fake')
     >>> mockTwilio = MagicMock()


### PR DESCRIPTION
We probably should try an exponential backoff instead but 1 seconds default retry delay is ok, I think.
