### PR TITLE
Include Host Root CAs in Docker Mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
     - npm_config_cache=/cache/npm
     - YARN_CACHE_FOLDER=/cache/yarn
     - PIP_CACHE_DIR=/cache/pip
+    - REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+    - NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
     cap_add:
     - NET_ADMIN
     sysctls:


### PR DESCRIPTION
- Loads the root CAs from the host system into the develop container.
- Sets environment variables for node and requests to make sure they use the container's configured roots.