### PR TITLE
rex.deploy: added re_replace() function

### DIFF
--- a/src/rex.deploy/README.rst
+++ b/src/rex.deploy/README.rst
@@ -1421,6 +1421,10 @@ PostgreSQL functions:
     Extracts field ``name`` from a JSON object as a JSON object.
 ``re_matches(text, pat)``
     Checks if ``text`` matches the regular expression ``pat``.
+``re_replace(text, pat, repl, [flags])``
+    Replaces the substrings that match the regular expression ``pat`` with
+    ``repl``.  By default, performs *case-insensitive* comparison and replaces
+    *all* occurrences of the pattern.
 ``ft_matches(text, key)``
     Checks if ``text`` contains ``key`` by performing full-text search on
     ``text`` value.

--- a/src/rex.deploy/src/htsql_rex_deploy/tr/bind.py
+++ b/src/rex.deploy/src/htsql_rex_deploy/tr/bind.py
@@ -17,12 +17,12 @@ from htsql.core.tr.fn.bind import (BindCast, BindMonoFunction,
         match)
 from ..domain import JSONDomain
 from .lookup import select_identity
-from .signature import (REMatchesSig, FTMatchesSig, FTQueryMatchesSig,
-        FTHeadlineSig, FTQueryHeadlineSig, FTRankSig, FTQueryRankSig, JoinSig,
-        AbsSig, SignSig, CeilSig, FloorSig, DivSig, ModSig, ExpSig, PowSig,
-        LnSig, Log10Sig, LogSig, PiSig, ACosSig, ASinSig, ATanSig, ATan2Sig,
-        CosSig, CotSig, SinSig, TanSig, RandomSig, JSONGetSig, JSONGetJSONSig,
-        MedianSig, WidthBucketSig)
+from .signature import (REMatchesSig, REReplaceSig, REReplaceWithFlagsSig,
+    FTMatchesSig, FTQueryMatchesSig, FTHeadlineSig, FTQueryHeadlineSig,
+    FTRankSig, FTQueryRankSig, JoinSig, AbsSig, SignSig, CeilSig, FloorSig,
+    DivSig, ModSig, ExpSig, PowSig, LnSig, Log10Sig, LogSig, PiSig, ACosSig,
+    ASinSig, ATanSig, ATan2Sig, CosSig, CotSig, SinSig, TanSig, RandomSig,
+    JSONGetSig, JSONGetJSONSig, MedianSig, WidthBucketSig)
 
 
 class SelectEntity(SelectRecord):
@@ -70,6 +70,30 @@ class BindREMatches(BindMonoFunction):
     signature = REMatchesSig
     domains = [TextDomain(), TextDomain()]
     codomain = BooleanDomain()
+
+
+class BindREMatches(BindMonoFunction):
+
+    call('re_matches')
+    signature = REMatchesSig
+    domains = [TextDomain(), TextDomain()]
+    codomain = BooleanDomain()
+
+
+class BindREReplace(BindMonoFunction):
+
+    call(('re_replace', 3))
+    signature = REReplaceSig
+    domains = [TextDomain(), TextDomain(), TextDomain()]
+    codomain = TextDomain()
+
+
+class BindREReplaceWithFlags(BindMonoFunction):
+
+    call(('re_replace', 4))
+    signature = REReplaceWithFlagsSig
+    domains = [TextDomain(), TextDomain(), TextDomain(), TextDomain()]
+    codomain = TextDomain()
 
 
 class BindFTMatches(BindMonoFunction):

--- a/src/rex.deploy/src/htsql_rex_deploy/tr/dump.py
+++ b/src/rex.deploy/src/htsql_rex_deploy/tr/dump.py
@@ -11,12 +11,13 @@ from htsql_pgsql.core.tr.dump import (
         PGSQLDumpDateIncrement, PGSQLDumpDateDecrement)
 from ..domain import JSONDomain
 from .signature import (
-        EscapeIdentitySig, REMatchesSig, FTMatchesSig, FTQueryMatchesSig,
-        FTHeadlineSig, FTQueryHeadlineSig, FTRankSig, FTQueryRankSig, JoinSig,
-        AbsSig, SignSig, CeilSig, FloorSig, DivSig, ModSig, ExpSig, PowSig,
-        LnSig, Log10Sig, LogSig, PiSig, ACosSig, ASinSig, ATanSig, ATan2Sig,
-        CosSig, CotSig, SinSig, TanSig, RandomSig, ToJSONSig, JSONGetSig,
-        JSONGetJSONSig, MedianSig, WidthBucketSig)
+        EscapeIdentitySig, REMatchesSig, REReplaceSig, REReplaceWithFlagsSig,
+        FTMatchesSig, FTQueryMatchesSig, FTHeadlineSig, FTQueryHeadlineSig,
+        FTRankSig, FTQueryRankSig, JoinSig, AbsSig, SignSig, CeilSig, FloorSig,
+        DivSig, ModSig, ExpSig, PowSig, LnSig, Log10Sig, LogSig, PiSig,
+        ACosSig, ASinSig, ATanSig, ATan2Sig, CosSig, CotSig, SinSig, TanSig,
+        RandomSig, ToJSONSig, JSONGetSig, JSONGetJSONSig, MedianSig,
+        WidthBucketSig)
 
 
 class DeployDumpDateIncrement(PGSQLDumpDateIncrement):
@@ -67,6 +68,18 @@ class DumpREMatches(DumpFunction):
 
     adapt(REMatchesSig)
     template = "({lop} ~* {rop})"
+
+
+class DumpREReplace(DumpFunction):
+
+    adapt(REReplaceSig)
+    template = "REGEXP_REPLACE({op}, {pat}, {repl}, 'ig')"
+
+
+class DumpREReplaceWithFlags(DumpFunction):
+
+    adapt(REReplaceWithFlagsSig)
+    template = "REGEXP_REPLACE({op}, {pat}, {repl}, {flags})"
 
 
 class DumpFTMatches(DumpFunction):

--- a/src/rex.deploy/src/htsql_rex_deploy/tr/signature.py
+++ b/src/rex.deploy/src/htsql_rex_deploy/tr/signature.py
@@ -20,6 +20,25 @@ class REMatchesSig(BinarySig):
     pass
 
 
+class REReplaceSig(Signature):
+
+    slots = [
+            Slot('op'),
+            Slot('pat'),
+            Slot('repl'),
+    ]
+
+
+class REReplaceWithFlagsSig(Signature):
+
+    slots = [
+            Slot('op'),
+            Slot('pat'),
+            Slot('repl'),
+            Slot('flags')
+    ]
+
+
 class FTMatchesSig(BinarySig):
     pass
 

--- a/src/rex.deploy/test/test_htsql_rex_deploy.rst
+++ b/src/rex.deploy/test/test_htsql_rex_deploy.rst
@@ -390,6 +390,33 @@ To search for a text field with a regular expression, use function
     -+------------------------+-------------------------+-
      | true                   | false                   |
 
+To search and replace a text value with a regular expression, use function
+``re_replace``::
+
+    >>> q = Query(''' {re_replace('Alice Ball', '([a-z]+) ([a-z]+)', '\\2, \\1')} ''')
+    >>> print(q.format('txt').decode('utf-8'))          # doctest: +NORMALIZE_WHITESPACE
+     | re_replace('Alice Ball','([a-z]+) ([a-z]+)','\2, \1') |
+    -+-------------------------------------------------------+-
+     | Ball, Alice                                           |
+
+By default, ``re_replace`` performs *case-insensitive* comparison and replaces
+*all* occurrences of a pattern::
+
+    >>> q = Query(''' {re_replace('Alice.Ball@example.com', '[a-z]', 'X')} ''')
+    >>> print(q.format('txt').decode('utf-8'))          # doctest: +NORMALIZE_WHITESPACE
+     | re_replace('Alice.Ball@example.com','[a-z]','X') |
+    -+--------------------------------------------------+-
+     | XXXXX.XXXX@XXXXXXX.XXX                           |
+
+To change this behavior, specify the desired options as the last parameter to
+the function::
+
+    >>> q = Query(''' {re_replace('Alice.Ball@example.com', '[a-z]', 'X', 'g')} ''')
+    >>> print(q.format('txt').decode('utf-8'))          # doctest: +NORMALIZE_WHITESPACE
+     | re_replace('Alice.Ball@example.com','[a-z]','X','g') |
+    -+------------------------------------------------------+-
+     | AXXXX.BXXX@XXXXXXX.XXX                               |
+
 ``rex.deploy`` also provides interface for full-text search::
 
     >>> q = Query(''' {ft_matches('queries', 'query'), ft_matches('requests', 'query')} ''')


### PR DESCRIPTION
`re_replace(text, pat, repl)` calls `REGEXP_REPLACE(text, pat, repl, 'ig')`. (`i` to match the behavior of `re_matches()`, `g` because it's almost always what you want).
`re_replace(text, pat, repl, flags)` calls `REGEXP_REPLACE(text, pat, repl, flags)`.