### PR TITLE
rex pyshell: fixed NameError

### DIFF
--- a/src/rex.ctl/src/rex/ctl/std.py
+++ b/src/rex.ctl/src/rex/ctl/std.py
@@ -629,8 +629,8 @@ class PyShellTask(RexTaskWithProject):
                 code.interact(banner, local=namespace)
             else:
                 banner = self.IPYTHON_BANNER.format(name=name, app=app)
-                sh = InteractiveShellEmbed(banner1=banner)
-                sh(local_ns=namespace)
+                sh = InteractiveShellEmbed(banner1=banner, user_ns=namespace)
+                sh()
 
 
 class ConfigurationTopic(Topic):


### PR DESCRIPTION
This PR fixes NameError in `rex pyshell` when accessing a global variable from a closure or a list comprehension.

An example of the error:
```
In [1]: x = 1

In [2]: (lambda: x)()
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
/app/src/rex.ctl/src/rex/ctl/std.py in <module>
----> 1 (lambda: x)()

/app/src/rex.ctl/src/rex/ctl/std.py in <lambda>()
----> 1 (lambda: x)()

NameError: name 'x' is not defined
```

After the fix:
```
In [1]: x = 1

In [2]: (lambda: x)()
Out[2]: 1
```