### PR TITLE
rex.setup: pin docutils to >=0.12, <0.13

### DIFF
--- a/src/rex.setup/setup.py
+++ b/src/rex.setup/setup.py
@@ -43,4 +43,5 @@ setup(
         'sphinxcontrib-texfigure >=0.1.0, <0.2',
         'sphinxcontrib-htsql >=0.1.0, <0.2',
         'Sphinx >=1.2, <1.8',
+        'docutils >=0.12,<0.13',
     ], )


### PR DESCRIPTION
This is the version pinned in rex.widget and rex.action so this is what's used in the codebase.

But in the rex.setup's tests we are installing only rex.setup and rex.setup_demo and the newly released docutils 0.18 breaks the old Sphinx we are using. So the pin of docutils version at rex.setup fixes this.

cc @kcrusty @alexvoronoi 