### PR TITLE
rex.notebook: upgrade Cython version

### DIFF
--- a/Makefile.src
+++ b/Makefile.src
@@ -77,7 +77,7 @@ TOOL_PY = \
 	Sphinx==1.7.6 \
 	sphinx-rtd-theme==0.4.3 \
 	honcho==1.0.1 \
-	Cython==0.29.15 \
+	Cython==0.29.24 \
 	tidypy
 
 


### PR DESCRIPTION
Newly released 1.21.4 is while trying to build a wheel. We can reconsider when/if they add wheels for this version back.
